### PR TITLE
Fix pauseGame bug

### DIFF
--- a/gameManager.js
+++ b/gameManager.js
@@ -10,7 +10,8 @@ class GameManager {
         this.enemyBullets = [];
         this.explosions = [];
         this.gameOver = false;
-        this.pauseGame = true;
+        // indicates whether the main loop should run
+        this.isRunning = true;
         this.lastTouchX = 0;
         this.lastTouchY = 0;
         this.fireRate = 150; // 150 milliseconds = 0.1 seconds
@@ -459,12 +460,14 @@ class GameManager {
     pauseGame() {
         // Code pour mettre le jeu en pause
         this.gameState = "paused";
+        this.isRunning = false;
         console.log("Jeu en pause");
     }
 
     resumeGame() {
         // Code pour reprendre le jeu
         this.gameState = "game";
+        this.isRunning = true;
         console.log("Jeu repris");
     }
 

--- a/sketch.js
+++ b/sketch.js
@@ -31,8 +31,8 @@ function setup() {
 }
 
 function draw() {
-    if (gameManager.pauseGame == 1)
-    gameManager.manageGame();
+    if (gameManager.isRunning)
+        gameManager.manageGame();
 }
 
 function touchStarted() {


### PR DESCRIPTION
## Summary
- fix crash due to `pauseGame` property overriding the method
- rename pause flag to `isRunning` and adjust draw loop

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68441c7e4f9483268d58b40ffb872380