### PR TITLE
Implement triple shot power-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Toutes les modifications notables à ce projet seront documentées dans ce fichier.
 
+## [0.4.5] - 2025-04-30 - Triple Shot Edition
+
+- Ajout du power-up **Triple Tir** offrant trois projectiles simultanés.
+- Mise à jour de la génération et de la collecte des power-ups pour prendre en charge ce nouveau bonus.
+
 ## [0.4.4] - 2025-03-30 - Power-Up Graphics Edition
 
 - Mise à jour complète des graphismes des power-ups (PowerUp00 à PowerUp05)

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -80,7 +80,7 @@ SpaceCarnage/
 
 ### 3.1 Système de Combat
 - Tir simple et double
-- Triple tir (power-up)
+- Triple tir (power-up, nouveau)
 - Système de bouclier
 - Système de vies
 - Dégâts et destruction
@@ -91,7 +91,7 @@ Types disponibles :
 - Vie supplémentaire
 - Multiplicateur de points
 - Double tir
-- Triple tir
+- Triple tir (nouveau)
 
 ### 3.3 Système de Score
 - Points basés sur la destruction d'ennemis

--- a/gameManager.js
+++ b/gameManager.js
@@ -372,7 +372,7 @@ class GameManager {
                             if (Math.random() < 0.4) {  // 40% de chances pour une extra life
                                 powerUp.type = 'extraLife';
                             } else {
-                                let allowedTypes = ['shield', 'pointsMultiplier', 'doubleShot', 'lateralShoot'];
+                                let allowedTypes = ['shield', 'pointsMultiplier', 'doubleShot', 'lateralShoot', 'tripleShot'];
                                 powerUp.type = allowedTypes[Math.floor(Math.random() * allowedTypes.length)];
                             }
                             powerUp.image = powerUp.getImageForType(powerUp.type);
@@ -381,7 +381,7 @@ class GameManager {
                             this.score += 5;
                             // Pour les ennemis normaux, on exclut l'extraLife et on ne droppe le power-up qu'avec une probabilité de 40%
                             if (Math.random() < this.getAdjustedDropChance(0.4)) {
-                                let allowedTypes = ['shield', 'pointsMultiplier', 'doubleShot', 'lateralShoot'];
+                                let allowedTypes = ['shield', 'pointsMultiplier', 'doubleShot', 'lateralShoot', 'tripleShot'];
                                 let chosenType = allowedTypes[Math.floor(Math.random() * allowedTypes.length)];
                                 
                                 let powerUp = new PowerUp(this.enemies[j].x, this.enemies[j].y, 16, this.powerupImages);

--- a/powerup.js
+++ b/powerup.js
@@ -11,7 +11,7 @@ class PowerUp {
     }
 
     getRandomType() {
-        const types = ['shield', 'extraLife', 'pointsMultiplier', 'doubleShot', 'lateralShoot'];
+        const types = ['shield', 'extraLife', 'pointsMultiplier', 'doubleShot', 'lateralShoot', 'tripleShot'];
         return types[Math.floor(Math.random() * types.length)];
     }
 
@@ -35,6 +35,8 @@ class PowerUp {
         if (this.type === 'lateralShoot') {
             scaleFactor = 1.5;
         } else if (this.type === 'doubleShot') {
+            scaleFactor = 1.3;
+        } else if (this.type === 'tripleShot') {
             scaleFactor = 1.3;
         }
         if (this.image) {

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ Dans Space Carnage, chaque power-up est une clé magique qui peut renverser le c
   - **Effet** : Libérez une puissance de feu dévastatrice avec un double rayon laser qui annihile tout sur son passage !
   - **Durée** : 5 secondes de chaos explosif, prolongées à 10 secondes en mode boss !
 
-- **⚡ Triple Tir (tripleShot)**
+- **⚡ Triple Tir (tripleShot)** *(nouveau)*
   - **Effet** : Déchaînez un déluge de projectiles avec trois rayons simultanés pour une destruction maximale !
   - **Durée** : 6 secondes d'attaque dévastatrice, prolongées à 12 secondes en mode boss !
 

--- a/sketch.js
+++ b/sketch.js
@@ -112,9 +112,14 @@ function loadPowerupImage() {
         () => { console.error('Erreur lors du chargement de l\'image doubleShot'); }
     );
     powerupImages.lateralShoot = loadImage(
-        'images/PowerUp04.png', 
+        'images/PowerUp04.png',
         () => { console.log('Image lateralShoot chargée avec succès'); },
         () => { console.error('Erreur lors du chargement de l\'image lateralShoot'); }
+    );
+    powerupImages.tripleShot = loadImage(
+        'images/PowerUp06.png',
+        () => { console.log('Image tripleShot chargée avec succès'); },
+        () => { console.error('Erreur lors du chargement de l\'image tripleShot'); }
     );
 }
 

--- a/spaceship.js
+++ b/spaceship.js
@@ -19,6 +19,8 @@ class Spaceship {
         this.doubleShotActive = false;
         // Propriété pour le lateral shoot
         this.lateralShootActive = false;
+        // Propriété pour le triple tir
+        this.tripleShotActive = false;
     }
 
     show() {
@@ -155,6 +157,10 @@ class Spaceship {
                     this.doubleShotActive = false;
                 }, 5000 * multiplier);
                 break;
+            case 'tripleShot':
+                // Active le triple tir pendant 6 secondes (6000 ms)
+                this.activateTripleShot(6000 * multiplier);
+                break;
             case 'lateralShoot':
                 // Activation de l'effet Latéral Shoot (durée de 6 secondes, multipliée si issu d'un boss)
                 this.activateLateralShoot(6000 * multiplier);
@@ -212,6 +218,13 @@ class Spaceship {
         }, duration);
     }
 
+    activateTripleShot(duration) {
+        this.tripleShotActive = true;
+        setTimeout(() => {
+            this.tripleShotActive = false;
+        }, duration);
+    }
+
     /**
      * Méthode pour refléter une balle lorsque celle-ci entre en collision avec le bouclier.
      * La direction de la balle est inversée en fonction de sa position relative au vaisseau.
@@ -262,8 +275,14 @@ class Spaceship {
         const centerX = this.x + this.size / 2;
         const centerY = this.y; // Tir depuis le haut du vaisseau
 
-        // Tir principal (simple ou double)
-        if (this.doubleShotActive) {
+        // Tir principal (simple, double ou triple)
+        if (this.tripleShotActive) {
+            const offset = 20;
+            const bulletCenter = new Bullet(centerX, centerY, 0, -1);
+            const bulletLeft = new Bullet(centerX - offset, centerY, 0, -1);
+            const bulletRight = new Bullet(centerX + offset, centerY, 0, -1);
+            projectiles.push(bulletCenter, bulletLeft, bulletRight);
+        } else if (this.doubleShotActive) {
             const offset = 15;
             const bulletLeft = new Bullet(centerX - offset, centerY, 0, -1);
             const bulletRight = new Bullet(centerX + offset, centerY, 0, -1);


### PR DESCRIPTION
## Summary
- add new **tripleShot** power-up
- load triple shot sprite
- support triple shot in spaceship shooting logic
- allow enemies and bosses to drop the new power-up
- document the new feature

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68441de7f21083269d70606dd906535c