### PR TITLE
Fix undefined gameManager errors

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -34,15 +34,21 @@ function draw() {
 }
 
 function touchStarted() {
-    gameManager.handleTouchPressed();
+    if (gameManager) {
+        gameManager.handleTouchPressed();
+    }
 }
 
 function touchEnded() {
-    gameManager.handleTouchReleased();
+    if (gameManager) {
+        gameManager.handleTouchReleased();
+    }
 }
 
 function mousePressed() {
-    gameManager.handleMousePressed();
+    if (gameManager) {
+        gameManager.handleMousePressed();
+    }
 }
 
 function keyPressed() {
@@ -138,6 +144,9 @@ function goFullScreen() {
 }
 
 document.addEventListener('visibilitychange', function() {
+    if (!gameManager) {
+        return;
+    }
     if (document.hidden) {
         // Mettre le jeu en pause
         gameManager.pauseGame();


### PR DESCRIPTION
## Summary
- prevent event handler crashes when `gameManager` isn't initialized

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6844436ca9c883268866e02e4d442376